### PR TITLE
add expose for other default ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,7 @@ RUN wget -P /opt https://s3-us-west-2.amazonaws.com/wso2-stratos/wso2esb-4.8.1.z
 
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 EXPOSE 9443
+EXPOSE 9763
+EXPOSE 8243
+EXPOSE 8280
 CMD ["/opt/wso2esb-4.8.1/bin/wso2server.sh"]
-


### PR DESCRIPTION
Needed these ports also to do some testing;
- 8243 - Passthrough or NIO HTTPS transport
- 8280 - Passthrough or NIO HTTP transport
- 9763 - HTTP servlet transport

Taken from:
https://docs.wso2.com/display/ESB470/Default+Ports+of+WSO2+Products
